### PR TITLE
Perform GID mapping in userspace

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ To use the library, simply import the package:
 
 ```go
 import (
-	// Create a new user namespace. This will map the current UID to 0.
+	// Create a new user namespace. This will map the current UID/GID to 0.
 	_ "github.com/howardjohn/unshare-go/userns"
 	// Create a new network namespace. This will have the 'lo' interface ready but nothing else.
 	_ "github.com/howardjohn/unshare-go/netns"
@@ -58,6 +58,7 @@ import (
 
 func main() {
 	log.Println(os.Getuid()) // Returns 0, always
+	log.Println(os.Getgid()) // Returns 0, always
 	net.Listen("tcp", "127.0.0.1:80") // This works, even when the process is not run as root.
 }
 ```

--- a/example_userns_test.go
+++ b/example_userns_test.go
@@ -2,11 +2,15 @@ package unshare_test
 
 import (
 	"fmt"
-	_ "github.com/howardjohn/unshare-go/userns"
 	"os"
+
+	_ "github.com/howardjohn/unshare-go/userns"
 )
 
 func Example_UserNs() {
 	fmt.Println("Running as user", os.Getuid())
-	// Output: Running as user 0
+	fmt.Println("Running as group", os.Getgid())
+	// Output:
+	// Running as user 0
+	// Running as group 0
 }

--- a/userns/userns.go
+++ b/userns/userns.go
@@ -40,7 +40,7 @@ func init() {
 
 	// write deny in setgroups to disable setgroup(2) and enable writing to gid_map
 	data := []byte("deny\n")
-	err = os.WriteFile("/proc/self/setgroups", data, 0644)
+	err = os.WriteFile("/proc/self/setgroups", data, 0o644)
 	if err != nil {
 		fmt.Println("Error writing to setgroups:", err)
 	}

--- a/userns/userns.go
+++ b/userns/userns.go
@@ -39,10 +39,9 @@ func init() {
 	}
 
 	// write deny in setgroups to disable setgroup(2) and enable writing to gid_map
-	data := []byte("deny\n")
-	err = os.WriteFile("/proc/self/setgroups", data, 0o644)
+	err = os.WriteFile("/proc/self/setgroups", []byte("deny\n"), 0o644)
 	if err != nil {
-		fmt.Println("Error writing to setgroups:", err)
+		panic(fmt.Errorf("failed to deny setgroups: %v", err).Error())
 	}
 
 	err = WriteMap("/proc/self/gid_map", map[uint32]uint32{


### PR DESCRIPTION
This will add the mapping of currentGID to 0 when creating a new namespace.
As a prerequisite the code is denying the usage of the setgroup(2) syscall in order to enable the editing of the gid mapping.

This is documented [here](https://man7.org/linux/man-pages/man7/user_namespaces.7.html)
```
In the case of gid_map, use of the setgroups(2) system
call must first be denied by writing "deny" to the/proc/pid/setgroups file (see below)
before writing to gid_map.
```